### PR TITLE
Keep tree from previous tick

### DIFF
--- a/Car.ts
+++ b/Car.ts
@@ -77,6 +77,7 @@ export class Car{
     auto: boolean = true;
     goal: State | null = null;
     path: StateWithCost[] | null = null;
+    searchNodes = 100;
     searchState?: {
         searchTree: StateWithCost[],
         treeSize: number,
@@ -317,7 +318,7 @@ export class Car{
                 // Descending the tree is not a good way to sample a random node in a tree, since
                 // the chances are much higher on shallow nodes. We want to give chances uniformly
                 // among all nodes in the tree, so we randomly pick one from a linear list of all nodes.
-                for(let i = 0; i < 100; i++){
+                for(let i = 0; i < this.searchNodes; i++){
                     const idx = Math.floor(Math.random() * nodes.length);
                     traceTree(nodes[idx]);
                 }

--- a/Car.ts
+++ b/Car.ts
@@ -239,7 +239,6 @@ export class Car{
                             {
                                 existingNode.cost = node.cost;
                                 const toIndex = existingNode.from?.to.indexOf(existingNode);
-                                console.log(`toIndex: ${toIndex}`)
                                 if(toIndex !== undefined && 0 <= toIndex)
                                     existingNode.from?.to.splice(toIndex, 1);
                                 else{

--- a/Car.ts
+++ b/Car.ts
@@ -283,7 +283,9 @@ export class Car{
                 for(let root of this.searchState.searchTree)
                     enumTree(root);
             }
+
             console.log(`Using existing tree with ${nodes.length} nodes`);
+
             const traceTree = (root: StateWithCost, depth: number = 1, expandDepth = 1) => {
                 if(depth < 1)
                     return;
@@ -299,15 +301,22 @@ export class Car{
                         traceTree(root.to[idx], depth - 1, expandDepth);
                     }
                 }
-                // nodes.push(root);
                 if(this.searchState)
                     this.searchState.treeSize++;
             };
+
+            if(0 < nodes.length && nodes.length < 10000){
+                // Descending the tree is not a good way to sample a random node in a tree, since
+                // the chances are much higher on shallow nodes. We want to give chances uniformly
+                // among all nodes in the tree, so we randomly pick one from a linear list of all nodes.
+                for(let i = 0; i < 100; i++){
+                    const idx = Math.floor(Math.random() * nodes.length);
+                    traceTree(nodes[idx]);
+                }
+            }
+
             const treeSize = this.searchState.treeSize;
             this.searchState.treeSize = 0;
-            // nodes.push(this.searchState.searchTree);
-            for(let root of this.searchState.searchTree)
-                traceTree(root, 10, treeSize < 5000 ? 1 : 0);
             this.searchState.goal = this.goal;
         }
         else if(this.goal){

--- a/index.html
+++ b/index.html
@@ -19,6 +19,11 @@
             <input type="checkbox" id="switchBack"> Search switch back
         </label>
 
+        <div>
+            Search nodes per tick=<span id="searchNodesLabel"></span>
+            <input id="searchNodesInput" type="range" max="1000" min="1" step="1" value="100">
+        </div>
+
         <h1>Controls</h1>
         <p>Drag anywhere on the canvas to set destination.</p>
         <p>You can only control with WASD keys when autopilot is off.</p>

--- a/index.ts
+++ b/index.ts
@@ -203,7 +203,7 @@ let pendingSearch = false;
 
 webWorker.onmessage = (e) => {
     if(car.auto){
-        searchTree = e.data.searchTree;
+        searchTree = e.data.searchNodes;
         car.path = e.data.path;
     }
     pendingSearch = false;

--- a/index.ts
+++ b/index.ts
@@ -141,7 +141,7 @@ function render(){
     if(carElem)
         carElem.innerHTML = `x: ${car.x.toFixed(2)}, y: ${car.y.toFixed(2)}, heading: ${car.angle.toFixed(2)
             } steer: ${car.steer.toFixed(2)
-            } relativeAngle: ${car.nextRelativeAngle().toFixed(2)} searchTree size: ${searchTree.length}`;
+            } relativeAngle: ${(car.nextRelativeAngle() / Math.PI).toFixed(2)} searchTree size: ${searchTree.length}`;
     if(autopilotElem)
         autopilotElem.checked = car.auto;
 }
@@ -261,6 +261,10 @@ function step(){
             },
         })
     }
+    webWorker.postMessage({
+        type: "move",
+        car: {x: car.x, y: car.y, angle: car.angle},
+    });
 
     render();
 

--- a/index.ts
+++ b/index.ts
@@ -220,6 +220,10 @@ webWorker.onmessage = (e) => {
         const connectionsArray = new Int32Array(e.data.connections);
         searchTree = [];
         for(let i = 0; i < connectionsArray.length / 2; i++){
+            if(nodes.length <= connectionsArray[i * 2])
+                throw "no way";
+                if(nodes.length <= connectionsArray[i * 2 + 1])
+                throw "no way2";
             searchTree.push([
                 nodes[connectionsArray[i * 2]],
                 nodes[connectionsArray[i * 2 + 1]],

--- a/index.ts
+++ b/index.ts
@@ -83,6 +83,28 @@ function toggleAutopilot(){
 
 autopilotElem?.addEventListener("click", toggleAutopilot);
 
+function sliderInit(sliderId: string, labelId: string, writer: (value: number) => void){
+    const slider = document.getElementById(sliderId) as HTMLInputElement;
+    const label = document.getElementById(labelId);
+    if(!slider || !label)
+        return;
+    label.innerHTML = slider.value;
+
+    const paramsContainer = document.getElementById("paramsContainer");
+
+    const updateFromInput = (_event: Event) => {
+        let value = label.innerHTML = slider.value;
+        if(value !== undefined)
+            writer(parseInt(value));
+    }
+    slider.addEventListener("input", updateFromInput);
+    return {elem: slider};
+}
+
+sliderInit("searchNodesInput", "searchNodesLabel", (value: number) => {
+    car.searchNodes = value;
+});
+
 function render(){
     const ctx = canvas?.getContext("2d");
     const hit = room.checkHit(car);
@@ -258,6 +280,7 @@ function step(){
                 speed: car.speed,
                 auto: car.auto,
                 goal: car.goal,
+                searchNodes: car.searchNodes,
             },
         })
     }

--- a/search.ts
+++ b/search.ts
@@ -3,7 +3,8 @@ import { Room } from './Room.ts';
 
 console.log("search called");
 
-let room = new Room(200, 200);
+const room = new Room(200, 200);
+const car = new Car();
 
 onmessage = function(e) {
     if(e.data.type === "initRoom"){
@@ -13,14 +14,13 @@ onmessage = function(e) {
     }
     else if(e.data.type === "search"){
         console.log('initRoom Message received from main script: ' + e.data);
-        let car = new Car();
         car.copyFrom(e.data.car);
-        const searchTree: [StateWithCost, StateWithCost][] = [];
+        const searchNodes: [StateWithCost, StateWithCost][] = [];
         car.search(20, room, (prevState, nextState) => {
-            searchTree.push([prevState, nextState]);
+            searchNodes.push([prevState, nextState]);
         }, e.data.switchBack);
         self.postMessage({
-            searchTree,
+            searchNodes,
             path: car.path,
         });
     }

--- a/search.ts
+++ b/search.ts
@@ -12,8 +12,11 @@ onmessage = function(e) {
         room.width = e.data.width;
         room.height = e.data.height;
     }
+    else if(e.data.type === "move"){
+        car.moveFromMsg(e.data.car);
+        car.followPath();
+    }
     else if(e.data.type === "search"){
-        console.log('initRoom Message received from main script: ' + e.data);
         car.copyFrom(e.data.car);
         const searchNodes: [number, number][] = [];
         const ret = car.search(5, room, (prevState, nextState) => {
@@ -32,7 +35,6 @@ onmessage = function(e) {
             };
             console.log(`Before Transfer: ${msg.nodes.byteLength}, ${connectionBuffer.byteLength}`);
             self.postMessage(msg, [msg.nodes, msg.connections]);
-            console.log(`After Transferred: ${msg.nodes.byteLength}, ${connectionBuffer.byteLength}`);
         } catch(e) {
             console.error("Stack overflow!!!!!");
         }

--- a/search.ts
+++ b/search.ts
@@ -16,7 +16,7 @@ onmessage = function(e) {
         console.log('initRoom Message received from main script: ' + e.data);
         car.copyFrom(e.data.car);
         const searchNodes: [number, number][] = [];
-        const ret = car.search(20, room, (prevState, nextState) => {
+        const ret = car.search(5, room, (prevState, nextState) => {
             searchNodes.push([prevState.id, nextState.id]);
         }, e.data.switchBack);
         const connectionsArray = new Int32Array(searchNodes.length * 2);


### PR DESCRIPTION
Previously, we discarded the entire tree every tick, which makes not only the path finding inefficient (by not utilizing the effort in the previous ticks) but also the path unstable from tick to tick, because the tree is completely different every time.

We can keep the tree structure in a state variable in the web worker and keep updating it. We can also apply usual RRT* optimization if a new node shortcuts existing path.

We still have problems that the car can stuck on a wall because our control is still terrible.
![image](https://user-images.githubusercontent.com/2798715/122639726-779ab980-d136-11eb-99e8-76e2b0e66eb6.png)

